### PR TITLE
bad merge

### DIFF
--- a/vars/withTools.groovy
+++ b/vars/withTools.groovy
@@ -15,7 +15,6 @@ def call(Map parameters = [:], body) {
   def vaultImage = parameters.get('vaultImage', globalDefaults.images.vault)
   def imagePullSecrets = parameters.get('imagePullSecrets', [])
   def volumes = parameters.get('volumes', [])
-  def workspaceVolume = emptyDirWorkspaceVolume(memory: false)
   def containersParam = parameters.get('containers', [])
   def containerTemplates = []
   def pvcWorkspaceName = parameters.get('workspaceClaimName', null)


### PR DESCRIPTION
Use disposable PVCs for workspaces, as emptyDir is not large enough to accomodate golang builds using client-go
Add more test namespace diagnostic output
make deploys to staging optional
documentation updates